### PR TITLE
use webpack-stream instead

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,7 @@ gulp.task('imgmin', function () {
 
 // wrapper for JS build, supporting both
 // minified and unminified versions
-function jsBuild(minify) {
+function jsBuild(isProduction) {
   return gulp.src('js/main.js')
     .pipe(webpackStream({
       entry : {
@@ -106,13 +106,14 @@ function jsBuild(minify) {
       output: {
         filename: '[name].js'
       },
-      plugins: minify ? [
+      plugins: isProduction ? [
         new webpack.optimize.UglifyJsPlugin({
           compress: {
             warnings: false
           }
         })
-      ] : []
+      ] : [],
+      pathinfo: !isProduction
     }, webpack))
     .pipe(gulp.dest('public/js'))
     .pipe(reload({ stream : true }));


### PR DESCRIPTION
This uses the [webpack-stream](https://github.com/shama/webpack-stream) module, which lets you get a more gulp-friendly interface to webpack. 
